### PR TITLE
Filter friend suggestions to avoid blacklisted users

### DIFF
--- a/Application/acceptBestSuggestion.js
+++ b/Application/acceptBestSuggestion.js
@@ -1,12 +1,12 @@
 var count = 25;
 var currentUserId = API.users.get()[0].id;
-var suggestions = API.friends.getSuggestions({ filter: "mutual", fields: "online,last_seen", count: count, offset: count * Args.offset }).items;
+var suggestions = API.friends.getSuggestions({ filter: "mutual", fields: "online,last_seen,blacklisted", count: count, offset: count * Args.offset }).items;
 var maxItem = [0, 0];
 var i = 0;
 while(i < suggestions.length)
 {
   var suggestion = suggestions[i];
-  if (suggestion.online) {
+  if (suggestion.online && !suggestion.blacklisted) {
     var mutualFriendsCount = API.friends.getMutual({ source_uid: currentUserId, target_uid: suggestion.id }).length;
     if (mutualFriendsCount > maxItem[1]) {
       maxItem = [suggestion.id, mutualFriendsCount];

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-8-118079a6
-Your prepared working directory: /tmp/gh-issue-solver-1760716788797
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-8-118079a6
+Your prepared working directory: /tmp/gh-issue-solver-1760716788797
+
+Proceed.


### PR DESCRIPTION
Fixes #8

## Problem

The script was failing with error 15 when calling `friends.getMutual`:

```json
{
  "execute_errors": [
    {
      "method": "friends.getMutual",
      "error_code": 15,
      "error_msg": "Access denied: you are in users blacklist"
    }
  ]
}
```

This error occurs when trying to get mutual friends with users who have blacklisted the current user.

## Solution

- Added `blacklisted` field to the `friends.getSuggestions` request
- Filter out suggestions where `blacklisted == 1` before calling `friends.getMutual`
- This prevents API calls to users who have blacklisted the current user

## Changes

- Updated `Application/acceptBestSuggestion.js`:
  - Added `blacklisted` to the `fields` parameter in line 3
  - Added `!suggestion.blacklisted` check in the condition on line 9

The script now skips users who have blacklisted the current user, avoiding the error 15 completely.