### PR TITLE
Filter out deactivated users before adding friends

### DIFF
--- a/Application/acceptAllFriendRequests.js
+++ b/Application/acceptAllFriendRequests.js
@@ -1,8 +1,14 @@
 var requests = API.friends.getRequests({ count: 23 }).items;
+var users = API.users.get({ user_ids: requests, fields: "deactivated" });
 var i = 0;
-while(i < requests.length)
+var addedUsers = [];
+while(i < users.length)
 {
-  API.friends.add({ user_id: requests[i] });
+  var user = users[i];
+  if (!user.deactivated) {
+    API.friends.add({ user_id: user.id });
+    addedUsers.push(user.id);
+  }
   i = i + 1;
 }
-return requests;
+return addedUsers;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-9-261f600c
-Your prepared working directory: /tmp/gh-issue-solver-1760717005732
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-9-261f600c
+Your prepared working directory: /tmp/gh-issue-solver-1760717005732
+
+Proceed.


### PR DESCRIPTION
## Summary

Fixes #9 - Prevents error 177 "Cannot add this user to friends as user not found" by checking user status before attempting to add them as friends.

## Problem

The `acceptAllFriendRequests.js` script was encountering error 177 when trying to add deactivated (deleted or banned) users as friends. The VK API returns this error when attempting to add users who:
- Have deleted accounts
- Have been banned
- Are blocked
- Have certain privacy restrictions

## Solution

Added user verification using `API.users.get()` with the `deactivated` field before attempting to add friends:

1. Fetch user information for all friend requests with the `deactivated` field
2. Filter out users who have the `deactivated` status (values: "deleted" or "banned")
3. Only add active users as friends
4. Return the list of successfully added users instead of all requests

## Changes

- Modified `Application/acceptAllFriendRequests.js` to check user status before adding
- Returns array of successfully added user IDs instead of all request IDs

## Testing

The solution follows the same pattern used in other scripts in the repository (e.g., `deleteFirstDeactivatedFriend.js`) for checking deactivated users.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)