### PR TITLE
Add retry logic for VK API error code 10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-13-3bd6c0c5
-Your prepared working directory: /tmp/gh-issue-solver-1760717565457
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-13-3bd6c0c5
+Your prepared working directory: /tmp/gh-issue-solver-1760717565457
+
+Proceed.

--- a/execute.sh
+++ b/execute.sh
@@ -3,19 +3,42 @@
 TOKEN_EXPIRED_ERROR_MESSAGE="User authorization failed: access_token has expired."
 TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE="User authorization failed: access_token was given to another ip address."
 NO_TOKEN_PASSED_ERROR_MESSAGE="User authorization failed: no access_token passed."
+INTERNAL_SERVER_ERROR_MESSAGE="Internal server error: Unknown error, try later"
 
-QUERY_RESULT=$(curl -s "$1")
+MAX_RETRIES=3
+RETRY_DELAY=5
 
-ERROR_MESSAGE=$(echo "$QUERY_RESULT" | jq .error.error_msg | tr -d '"')
+for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
+  QUERY_RESULT=$(curl -s "$1")
 
-echo "$QUERY_RESULT" | jq
+  ERROR_MESSAGE=$(echo "$QUERY_RESULT" | jq -r '.error.error_msg // empty')
+  ERROR_CODE=$(echo "$QUERY_RESULT" | jq -r '.error.error_code // empty')
 
-if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ]; then
-  # Get new access token
-  EMAIL=`cat email`
-  PASS=`cat pass`
-  cat vk_auth_token.side | jq '.tests[0].commands[2].value="'"$EMAIL"'" | .tests[0].commands[4].value="'"$PASS"'"' > vk_auth_token.temp
-  selenium-side-runner vk_auth_token.temp | grep -o "https.*" | sed -r "s|.*access_token=([^&]+)&.*|\1|" > access-token
-  rm vk_auth_token.temp
-  echo "Token is updated"
-fi;
+  echo "$QUERY_RESULT" | jq
+
+  # Check for internal server error (error_code 10)
+  if [ "$ERROR_CODE" = "10" ] || [ "$ERROR_MESSAGE" = "$INTERNAL_SERVER_ERROR_MESSAGE" ]; then
+    if [ $attempt -lt $MAX_RETRIES ]; then
+      echo "Internal server error (code 10). Retrying in ${RETRY_DELAY}s... (attempt $attempt/$MAX_RETRIES)"
+      sleep $RETRY_DELAY
+      continue
+    else
+      echo "Max retries reached. VK server is experiencing issues."
+      exit 1
+    fi
+  fi
+
+  # Check for token errors
+  if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ]; then
+    # Get new access token
+    EMAIL=`cat email`
+    PASS=`cat pass`
+    cat vk_auth_token.side | jq '.tests[0].commands[2].value="'"$EMAIL"'" | .tests[0].commands[4].value="'"$PASS"'"' > vk_auth_token.temp
+    selenium-side-runner vk_auth_token.temp | grep -o "https.*" | sed -r "s|.*access_token=([^&]+)&.*|\1|" > access-token
+    rm vk_auth_token.temp
+    echo "Token is updated"
+  fi
+
+  # If no error or error handled, break the loop
+  break
+done


### PR DESCRIPTION
## Summary

This PR fixes issue #13 by adding automatic retry logic for VK API error code 10 (Internal server error).

## Problem

The `accept-best-suggestion.sh` script was failing with error code 10:
```json
{
  "error": {
    "error_code": 10,
    "error_msg": "Internal server error: Unknown error, try later"
  }
}
```

This is a transient server-side error from VK's API that indicates temporary issues on their servers.

## Solution

Modified `execute.sh` to automatically retry failed requests when encountering error code 10:

- **Retry mechanism**: Up to 3 attempts with 5-second delays between retries
- **Error detection**: Checks both `error_code` and `error_msg` for reliability
- **User feedback**: Informative messages during retry attempts
- **Graceful failure**: Clear error message if max retries exceeded

## Changes

- Added configurable `MAX_RETRIES` (3) and `RETRY_DELAY` (5s) variables
- Wrapped API call in retry loop
- Improved error parsing using `jq -r` for cleaner string comparison
- Preserved existing token refresh functionality

## Testing

The solution handles error code 10 gracefully by retrying the request, allowing temporary VK server issues to resolve without manual intervention.

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)