### PR TITLE
Fix invalid access_token (4) error on acceptAllFriendRequests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-18-b63dd8f9
-Your prepared working directory: /tmp/gh-issue-solver-1760717984846
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-18-b63dd8f9
+Your prepared working directory: /tmp/gh-issue-solver-1760717984846
+
+Proceed.

--- a/execute.sh
+++ b/execute.sh
@@ -3,6 +3,7 @@
 TOKEN_EXPIRED_ERROR_MESSAGE="User authorization failed: access_token has expired."
 TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE="User authorization failed: access_token was given to another ip address."
 NO_TOKEN_PASSED_ERROR_MESSAGE="User authorization failed: no access_token passed."
+INVALID_TOKEN_ERROR_MESSAGE="User authorization failed: invalid access_token (4)."
 
 QUERY_RESULT=$(curl -s "$1")
 
@@ -10,7 +11,7 @@ ERROR_MESSAGE=$(echo "$QUERY_RESULT" | jq .error.error_msg | tr -d '"')
 
 echo "$QUERY_RESULT" | jq
 
-if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ]; then
+if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$INVALID_TOKEN_ERROR_MESSAGE" ]; then
   # Get new access token
   EMAIL=`cat email`
   PASS=`cat pass`


### PR DESCRIPTION
## Summary
This PR fixes issue #18 by adding automatic token refresh when the VK API returns an "invalid access_token (4)" error.

## Changes
- Updated `execute.sh` to detect and handle the "invalid access_token (4)" error message
- When this error occurs, the script now automatically acquires a new access token using the same mechanism that handles expired tokens and IP address changes

## Problem
The `acceptAllFriendRequests` function was failing with the error:
```
User authorization failed: invalid access_token (4).
```

The `execute.sh` script already handled several token-related errors (expired tokens, IP address changes, and missing tokens), but did not handle the specific "invalid access_token (4)" error.

## Solution
Added the invalid access_token error to the list of errors that trigger automatic token refresh. This allows the script to recover gracefully when encountering this error, maintaining the same behavior as other token-related issues.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)