### PR TITLE
Update Node.js installation instructions to fix chromedriver compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-19-658be4b0
-Your prepared working directory: /tmp/gh-issue-solver-1760718202887
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-19-658be4b0
+Your prepared working directory: /tmp/gh-issue-solver-1760718202887
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -19,30 +19,47 @@ CHECK GITIGNORE FILE.
    ```
    sudo apt install curl jq
    ```
-3. Install npm:
+3. Install Node.js and npm (version 14 or higher is required):
+
+   **Option A (Recommended): Using nvm**
+   ```bash
+   # Install nvm
+   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+   # Restart your terminal or run:
+   source ~/.bashrc
+   # Install latest LTS version of Node.js
+   nvm install --lts
+   nvm use --lts
    ```
-   sudo apt install npm
+
+   **Option B: Using NodeSource repository**
+   ```bash
+   # Install Node.js 20.x (LTS)
+   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+   sudo apt-get install -y nodejs
    ```
-   or using [nvm](https://github.com/nvm-sh/nvm).
+
+   **Note:** Do NOT use `sudo apt install npm` as it installs Node.js v10.19.0, which is too old for chromedriver (requires Node.js >= 14).
 4. Install selenium (for automatic token refreshing):
 
-   Without nvm:
-   ```
-   sudo npm install -g selenium-side-runner
-   ```
-   With nvm:
-   ```
+   If using nvm (Option A):
+   ```bash
    npm install -g selenium-side-runner
    ```
+   If using NodeSource (Option B):
+   ```bash
+   sudo npm install -g selenium-side-runner
+   ```
+
 5. Install Chrome driver (other browsers may be also used):
 
-   Without nvm:
-   ```
-   sudo npm install -g chromedriver --unsafe-perm=true --allow-root
-   ```
-   With nvm:
-   ```
+   If using nvm (Option A):
+   ```bash
    npm install -g chromedriver --unsafe-perm=true --allow-root
+   ```
+   If using NodeSource (Option B):
+   ```bash
+   sudo npm install -g chromedriver --unsafe-perm=true --allow-root
    ```
    Execute this command again for a new major version of the Chrome browser.
 


### PR DESCRIPTION
## Summary

Fixes #19

The issue was that following the original setup instructions (`sudo apt install npm`) would install Node.js v10.19.0, which is incompatible with chromedriver@107.0.3 that requires Node.js >= 14. This caused the error:

```
npm WARN notsup Unsupported engine for chromedriver@107.0.3: wanted: {"node":">=14"} (current: {"node":"10.19.0","npm":"6.14.4"})
```

## Changes

- ✅ Added clear Node.js version requirement (>= 14) in README.md
- ✅ Provided two proper installation options:
  - **Option A (Recommended)**: Using nvm to install latest LTS version
  - **Option B**: Using NodeSource repository to install Node.js 20.x
- ✅ Added explicit warning against using `sudo apt install npm`
- ✅ Updated selenium-side-runner and chromedriver installation steps to align with the two Node.js installation methods

## Testing

The changes have been verified to provide correct installation paths that will install Node.js >= 14, which is compatible with chromedriver@107.0.3 and later versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)