### PR TITLE
Fix invalid access_token error handling in execute.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-22-7d537d4d
-Your prepared working directory: /tmp/gh-issue-solver-1760718353785
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-22-7d537d4d
+Your prepared working directory: /tmp/gh-issue-solver-1760718353785
+
+Proceed.

--- a/execute.sh
+++ b/execute.sh
@@ -3,6 +3,7 @@
 TOKEN_EXPIRED_ERROR_MESSAGE="User authorization failed: access_token has expired."
 TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE="User authorization failed: access_token was given to another ip address."
 NO_TOKEN_PASSED_ERROR_MESSAGE="User authorization failed: no access_token passed."
+TOKEN_INVALID_ERROR_MESSAGE="User authorization failed: invalid access_token."
 
 QUERY_RESULT=$(curl -s "$1")
 
@@ -10,7 +11,7 @@ ERROR_MESSAGE=$(echo "$QUERY_RESULT" | jq .error.error_msg | tr -d '"')
 
 echo "$QUERY_RESULT" | jq
 
-if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ]; then
+if [ "$ERROR_MESSAGE" = "$TOKEN_EXPIRED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_WAS_GIVEN_TO_ANOTHER_IP_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$NO_TOKEN_PASSED_ERROR_MESSAGE" ] || [ "$ERROR_MESSAGE" = "$TOKEN_INVALID_ERROR_MESSAGE" ]; then
   # Get new access token
   EMAIL=`cat email`
   PASS=`cat pass`


### PR DESCRIPTION
The script was failing with repeated error messages:
`APIError: Code №5 - User authorization failed: invalid access_token (4).`

The issue occurred because `execute.sh` was missing handling for the "User authorization failed: invalid access_token." error message variant. The script only handled other token-related errors (expired, wrong IP, no token), but not this specific invalid token error.

## Changes Made

- Added `TOKEN_INVALID_ERROR_MESSAGE` constant to `execute.sh`
- Updated the error checking condition to include this new error message
- Now the script will properly regenerate the access token when this error occurs

## Bug Fixes

This also addresses the "too many requests" bug mentioned in the issue. Previously, when the invalid token error occurred, the script would continue making failed requests in a loop. Now it will properly catch the error and regenerate the token, preventing the spam of error messages.

Fixes #22